### PR TITLE
chore: add Dependabot config + auto-merge for patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# managed-by: seven-io/isms-tools/scripts/dependabot-rollout.sh
+# Dependabot config: scheduled + grouped security updates. Do not edit by hand;
+# changes should be made in the script and re-rolled out with FORCE_UPDATE=true.
+# See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      security-all:
+        applies-to: security-updates
+        patterns: ["*"]
+      minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "@seven/*"
+      - dependency-name: "@sms77/*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,26 @@
+name: Dependabot auto-merge
+# pull_request_target is required so that Dependabot-triggered runs get a token
+# with write permissions. Safe here because we never check out PR code — we only
+# call the gh CLI on the PR metadata.
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+      - name: Enable auto-merge for patch-only updates (version + security)
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'security-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automated rollout: scheduled weekly Dependabot scans, grouped security-update PRs, patch-only auto-merge when CI passes. Reduces PR noise and standardizes vuln-management across all repos.